### PR TITLE
feat: criar model Swagger

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -1,0 +1,15 @@
+name: On PR => Run tests
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go environment
+        uses: actions/setup-go@v5.0.2
+
+      - name: Run tests
+        run: go test ./...

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+examples/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cSpell.words": ["difmaj", "swaggo"]
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,10 @@
 module github.com/difmaj/swaggo-gen
 
 go 1.22.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.9.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,9 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/model/swagger.go
+++ b/internal/model/swagger.go
@@ -88,13 +88,16 @@ type Schema struct {
 	Required    []string          `json:"required,omitempty"`
 	ReadOnly    *bool             `json:"readOnly,omitempty"`
 	WriteOnly   *bool             `json:"writeOnly,omitempty"`
+	Minimum     *int              `json:"minimum,omitempty"`
+	MaxLength   *int              `json:"maxLength,omitempty"`
 }
 
 type Components struct {
-	Schemas         map[string]Schema         `json:"schemas"`
-	Responses       map[string]Response       `json:"responses"`
-	Parameters      map[string]Parameter      `json:"parameters"`
+	Schemas         map[string]Schema         `json:"schemas,omitempty"`
+	Responses       map[string]Response       `json:"responses,omitempty"`
+	Parameters      map[string]Parameter      `json:"parameters,omitempty"`
 	SecuritySchemes map[string]SecurityScheme `json:"securitySchemes,omitempty"`
+	Headers         map[string]Header         `json:"headers,omitempty"`
 }
 
 type SecurityScheme struct {
@@ -105,5 +108,6 @@ type SecurityScheme struct {
 type Security map[string]any
 
 type Tag struct {
-	Name string `json:"name"`
+	Name        *string `json:"name"`
+	Description *string `json:"description,omitempty"`
 }

--- a/internal/model/swagger.go
+++ b/internal/model/swagger.go
@@ -31,8 +31,8 @@ type PathItem struct {
 
 type Operation struct {
 	Tags        []string            `json:"tags"`
-	Summary     string              `json:"summary"`
-	Description string              `json:"description"`
+	Summary     *string             `json:"summary"`
+	Description *string             `json:"description"`
 	Parameters  []Parameter         `json:"parameters,omitempty"`
 	RequestBody *RequestBody        `json:"requestBody,omitempty"`
 	Responses   map[string]Response `json:"responses"`
@@ -48,12 +48,14 @@ type Parameter struct {
 }
 
 type RequestBody struct {
-	Required bool                 `json:"required"`
-	Content  map[string]MediaType `json:"content"`
+	Ref      *string               `json:"$ref,omitempty"`
+	Required *bool                 `json:"required,omitempty"`
+	Content  *map[string]MediaType `json:"content,omitempty"`
 }
 
 type Response struct {
-	Description string               `json:"description"`
+	Ref         *string              `json:"$ref,omitempty"`
+	Description *string              `json:"description,omitempty"`
 	Content     map[string]MediaType `json:"content,omitempty"`
 }
 
@@ -62,13 +64,13 @@ type MediaType struct {
 }
 
 type Schema struct {
-	Type       *string            `json:"type,omitempty"`
-	Ref        *string            `json:"$ref,omitempty"`
-	Items      *Schema            `json:"items,omitempty"`
-	Enum       []any              `json:"enum,omitempty"`
-	AllOf      []Schema           `json:"allOf,omitempty"`
-	Example    *any               `json:"example,omitempty"`
-	Properties *map[string]Schema `json:"properties,omitempty"`
+	Type       *string           `json:"type,omitempty"`
+	Ref        *string           `json:"$ref,omitempty"`
+	Items      *Schema           `json:"items,omitempty"`
+	Enum       []any             `json:"enum,omitempty"`
+	AllOf      []Schema          `json:"allOf,omitempty"`
+	Example    *any              `json:"example,omitempty"`
+	Properties map[string]Schema `json:"properties,omitempty"`
 }
 
 type Components struct {

--- a/internal/model/swagger.go
+++ b/internal/model/swagger.go
@@ -64,15 +64,19 @@ type MediaType struct {
 }
 
 type Schema struct {
-	Type       *string           `json:"type,omitempty"`
-	Ref        *string           `json:"$ref,omitempty"`
-	Items      *Schema           `json:"items,omitempty"`
-	Enum       []any             `json:"enum,omitempty"`
-	AllOf      []Schema          `json:"allOf,omitempty"`
-	Example    *any              `json:"example,omitempty"`
-	Format     *string           `json:"format,omitempty"`
-	Default    *any              `json:"default,omitempty"`
-	Properties map[string]Schema `json:"properties,omitempty"`
+	Type        *string           `json:"type,omitempty"`
+	Ref         *string           `json:"$ref,omitempty"`
+	Items       *Schema           `json:"items,omitempty"`
+	Enum        []any             `json:"enum,omitempty"`
+	AllOf       []Schema          `json:"allOf,omitempty"`
+	AnyOf       []Schema          `json:"anyOf,omitempty"`
+	OneOf       []Schema          `json:"oneOf,omitempty"`
+	Example     *any              `json:"example,omitempty"`
+	Format      *string           `json:"format,omitempty"`
+	Default     *any              `json:"default,omitempty"`
+	Properties  map[string]Schema `json:"properties,omitempty"`
+	Description *string           `json:"description,omitempty"`
+	Required    []string          `json:"required,omitempty"`
 }
 
 type Components struct {

--- a/internal/model/swagger.go
+++ b/internal/model/swagger.go
@@ -1,0 +1,84 @@
+package model
+
+type Swagger struct {
+	OpenAPI    string              `json:"openapi"`
+	Info       Info                `json:"info"`
+	Servers    []Server            `json:"servers"`
+	Paths      map[string]PathItem `json:"paths"`
+	Components Components          `json:"components"`
+	Security   []Security          `json:"security,omitempty"`
+	Tags       []Tag               `json:"tags,omitempty"`
+}
+
+type Info struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Version     string `json:"version"`
+}
+
+type Server struct {
+	URL         string `json:"url"`
+	Description string `json:"description"`
+}
+
+type PathItem struct {
+	Get    *Operation `json:"get,omitempty"`
+	Post   *Operation `json:"post,omitempty"`
+	Put    *Operation `json:"put,omitempty"`
+	Delete *Operation `json:"delete,omitempty"`
+	Patch  *Operation `json:"patch,omitempty"`
+}
+
+type Operation struct {
+	Tags        []string            `json:"tags"`
+	Summary     string              `json:"summary"`
+	Description string              `json:"description"`
+	Parameters  []Parameter         `json:"parameters,omitempty"`
+	RequestBody *RequestBody        `json:"requestBody,omitempty"`
+	Responses   map[string]Response `json:"responses"`
+}
+
+type Parameter struct {
+	Name        *string `json:"name,omitempty"`
+	In          *string `json:"in,omitempty"`
+	Description *string `json:"description,omitempty"`
+	Required    *bool   `json:"required,omitempty"`
+	Schema      *Schema `json:"schema,omitempty"`
+	Ref         *string `json:"$ref,omitempty"`
+}
+
+type RequestBody struct {
+	Required bool                 `json:"required"`
+	Content  map[string]MediaType `json:"content"`
+}
+
+type Response struct {
+	Description string               `json:"description"`
+	Content     map[string]MediaType `json:"content,omitempty"`
+}
+
+type MediaType struct {
+	Schema Schema `json:"schema"`
+}
+
+type Schema struct {
+	Type       *string            `json:"type,omitempty"`
+	Ref        *string            `json:"$ref,omitempty"`
+	Items      *Schema            `json:"items,omitempty"`
+	Enum       []any              `json:"enum,omitempty"`
+	AllOf      []Schema           `json:"allOf,omitempty"`
+	Example    *any               `json:"example,omitempty"`
+	Properties *map[string]Schema `json:"properties,omitempty"`
+}
+
+type Components struct {
+	Schemas    map[string]Schema    `json:"schemas"`
+	Responses  map[string]Response  `json:"responses"`
+	Parameters map[string]Parameter `json:"parameters"`
+}
+
+type Security map[string]any
+
+type Tag struct {
+	Name string `json:"name"`
+}

--- a/internal/model/swagger.go
+++ b/internal/model/swagger.go
@@ -70,6 +70,8 @@ type Schema struct {
 	Enum       []any             `json:"enum,omitempty"`
 	AllOf      []Schema          `json:"allOf,omitempty"`
 	Example    *any              `json:"example,omitempty"`
+	Format     *string           `json:"format,omitempty"`
+	Default    *any              `json:"default,omitempty"`
 	Properties map[string]Schema `json:"properties,omitempty"`
 }
 

--- a/internal/model/swagger.go
+++ b/internal/model/swagger.go
@@ -45,6 +45,8 @@ type Parameter struct {
 	Required    *bool   `json:"required,omitempty"`
 	Schema      *Schema `json:"schema,omitempty"`
 	Ref         *string `json:"$ref,omitempty"`
+	Minimum     *int    `json:"minimum,omitempty"`
+	Default     *any    `json:"default,omitempty"`
 }
 
 type RequestBody struct {
@@ -57,6 +59,13 @@ type Response struct {
 	Ref         *string              `json:"$ref,omitempty"`
 	Description *string              `json:"description,omitempty"`
 	Content     map[string]MediaType `json:"content,omitempty"`
+	Headers     map[string]Header    `json:"headers,omitempty"`
+}
+
+type Header struct {
+	Ref         *string `json:"$ref,omitempty"`
+	Description *string `json:"description,omitempty"`
+	Schema      *Schema `json:"schema,omitempty"`
 }
 
 type MediaType struct {
@@ -77,12 +86,20 @@ type Schema struct {
 	Properties  map[string]Schema `json:"properties,omitempty"`
 	Description *string           `json:"description,omitempty"`
 	Required    []string          `json:"required,omitempty"`
+	ReadOnly    *bool             `json:"readOnly,omitempty"`
+	WriteOnly   *bool             `json:"writeOnly,omitempty"`
 }
 
 type Components struct {
-	Schemas    map[string]Schema    `json:"schemas"`
-	Responses  map[string]Response  `json:"responses"`
-	Parameters map[string]Parameter `json:"parameters"`
+	Schemas         map[string]Schema         `json:"schemas"`
+	Responses       map[string]Response       `json:"responses"`
+	Parameters      map[string]Parameter      `json:"parameters"`
+	SecuritySchemes map[string]SecurityScheme `json:"securitySchemes,omitempty"`
+}
+
+type SecurityScheme struct {
+	Type  string `json:"type"`
+	Flows any    `json:"flows,omitempty"`
 }
 
 type Security map[string]any

--- a/internal/model/swagger_test.go
+++ b/internal/model/swagger_test.go
@@ -1,0 +1,43 @@
+package model_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/difmaj/swaggo-gen/internal/model"
+)
+
+func TestMarshalJson(t *testing.T) {
+	response := new(model.Swagger)
+
+	file, err := os.Open("../../examples/swagger-bling.json")
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer file.Close()
+
+	jsonRef, err := io.ReadAll(file)
+	if err != nil {
+		fmt.Println("Error reading file:", err)
+		os.Exit(1)
+	}
+
+	if err := json.Unmarshal(jsonRef, &response); err != nil {
+		fmt.Println("Error parsing ref:", err)
+	}
+
+	fmt.Println(response)
+
+	jsonStr, err := json.MarshalIndent(response, " ", "\t")
+
+	if err != nil {
+		fmt.Println("Error indenting:", err)
+		os.Exit(1)
+	}
+
+	fmt.Println(string(jsonStr))
+}

--- a/internal/model/swagger_test.go
+++ b/internal/model/swagger_test.go
@@ -2,42 +2,47 @@ package model_test
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"os"
 	"testing"
 
 	"github.com/difmaj/swaggo-gen/internal/model"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMarshalJson(t *testing.T) {
-	response := new(model.Swagger)
+	swaggerModel := new(model.Swagger)
 
 	file, err := os.Open("../../examples/swagger-bling.json")
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		t.Fatalf("Failed to open file: %v", err)
 	}
 	defer file.Close()
 
-	jsonRef, err := io.ReadAll(file)
+	fileContent, err := io.ReadAll(file)
 	if err != nil {
-		fmt.Println("Error reading file:", err)
-		os.Exit(1)
+		t.Fatalf("Error reading file: %v", err)
 	}
 
-	if err := json.Unmarshal(jsonRef, &response); err != nil {
-		fmt.Println("Error parsing ref:", err)
+	if err := json.Unmarshal(fileContent, &swaggerModel); err != nil {
+		t.Fatalf("Error parsing ref: %v", err)
 	}
 
-	fmt.Println(response)
-
-	jsonStr, err := json.MarshalIndent(response, " ", "\t")
-
+	modelIndented, err := json.MarshalIndent(swaggerModel, "", "    ")
 	if err != nil {
-		fmt.Println("Error indenting:", err)
-		os.Exit(1)
+		t.Fatalf("Error indenting: %v", err)
 	}
 
-	fmt.Println(string(jsonStr))
+	var originalJson map[string]interface{}
+	var marshaledJson map[string]interface{}
+
+	if err := json.Unmarshal(fileContent, &originalJson); err != nil {
+		t.Fatalf("Error unmarshaling original JSON: %v", err)
+	}
+
+	if err := json.Unmarshal(modelIndented, &marshaledJson); err != nil {
+		t.Fatalf("Error unmarshaling marshaled JSON: %v", err)
+	}
+
+	assert.Equal(t, originalJson, marshaledJson, "The JSON structures are not equal.")
 }

--- a/internal/model/swagger_test.go
+++ b/internal/model/swagger_test.go
@@ -33,8 +33,8 @@ func TestMarshalJson(t *testing.T) {
 		t.Fatalf("Error indenting: %v", err)
 	}
 
-	var originalJson map[string]interface{}
-	var marshaledJson map[string]interface{}
+	var originalJson map[string]any
+	var marshaledJson map[string]any
 
 	if err := json.Unmarshal(fileContent, &originalJson); err != nil {
 		t.Fatalf("Error unmarshaling original JSON: %v", err)

--- a/internal/model/swagger_test.go
+++ b/internal/model/swagger_test.go
@@ -3,7 +3,7 @@ package model_test
 import (
 	"encoding/json"
 	"io"
-	"os"
+	"net/http"
 	"testing"
 
 	"github.com/difmaj/swaggo-gen/internal/model"
@@ -13,15 +13,21 @@ import (
 func TestMarshalJson(t *testing.T) {
 	swaggerModel := new(model.Swagger)
 
-	file, err := os.Open("../../examples/swagger-bling.json")
-	if err != nil {
-		t.Fatalf("Failed to open file: %v", err)
-	}
-	defer file.Close()
+	url := "https://developer.bling.com.br/build/assets/openapi-2aa7117f.json"
 
-	fileContent, err := io.ReadAll(file)
+	resp, err := http.Get(url)
 	if err != nil {
-		t.Fatalf("Error reading file: %v", err)
+		t.Fatalf("Failed to download JSON: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Received non-200 response status: %s", resp.Status)
+	}
+
+	fileContent, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Error reading response body: %v", err)
 	}
 
 	if err := json.Unmarshal(fileContent, &swaggerModel); err != nil {


### PR DESCRIPTION
Cria um model swagger baseado no [arquivo do Bling ERP](https://developer.bling.com.br/build/assets/openapi-2aa7117f.json).

Além disso, implementa um workflow para execução de testes unitários ao abrir um PR.